### PR TITLE
Handle root context

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const windows = name => {
 };
 
 const linux = name => {
-	const username = homedir.split('/')[2];
+	const username = path.basename(homedir);
 
 	return {
 		data: env.XDG_DATA_HOME || path.join(homedir, '.local', 'share', name),


### PR DESCRIPTION
This solves: https://github.com/greenkeeperio/rc/issues/6

The issue is trying to split a path without a '/' and thus returning undefined, falling back to the default value 'root' solves this.