### PR TITLE
Add example locations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare namespace envPaths {
 		/**
 		Directory for data files.
 
-		Example locations:
+		Example locations (with the default `nodejs` suffix):
 
 		- macOS: `~/Library/Application Support/MyApp-nodejs`
 		- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Data` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Data`)
@@ -25,7 +25,7 @@ declare namespace envPaths {
 		/**
 		Directory for data files.
 
-		Example locations:
+		Example locations (with the default `nodejs` suffix):
 
 		- macOS: `~/Library/Preferences/MyApp-nodejs`
 		- Windows: `%APPDATA%\MyApp-nodejs\Config` (for example, `C:\Users\USERNAME\AppData\Roaming\MyApp-nodejs\Config`)
@@ -36,7 +36,7 @@ declare namespace envPaths {
 		/**
 		Directory for non-essential data files.
 
-		Example locations:
+		Example locations (with the default `nodejs` suffix):
 
 		- macOS: `~/Library/Caches/MyApp-nodejs`
 		- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Cache` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Cache`)
@@ -47,7 +47,7 @@ declare namespace envPaths {
 		/**
 		Directory for log files.
 
-		Example locations:
+		Example locations (with the default `nodejs` suffix):
 
 		- macOS: `~/Library/Logs/MyApp-nodejs`
 		- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Log` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Log`)
@@ -58,7 +58,7 @@ declare namespace envPaths {
 		/**
 		Directory for temporary files.
 
-		Example locations:
+		Example locations (with the default `nodejs` suffix):
 
 		- macOS: `/var/folders/jf/f2twvvvs5jl_m49tf034ffpw0000gn/T/MyApp-nodejs`
 		- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (for example, `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`)

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ declare namespace envPaths {
 		/**
 		Directory for temporary files.
 
-		Example locations (with the default `nodejs` [suffix](#suffix)):
+		Example locations:
 
 		- macOS: `/var/folders/jf/f2twvvvs5jl_m49tf034ffpw0000gn/T/MyApp-nodejs`
 		- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (for example, `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`)

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,26 +13,56 @@ declare namespace envPaths {
 	export interface Paths {
 		/**
 		Directory for data files.
+
+		Example locations:
+
+		- macOS: `~/Library/Application Support/MyApp-nodejs`
+		- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Data` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Data`)
+		- Linux: `~/.local/share/MyApp-nodejs` (or `$XDG_DATA_HOME/MyApp-nodejs`)
 		*/
 		readonly data: string;
 
 		/**
 		Directory for data files.
+
+		Example locations:
+
+		- macOS: `~/Library/Preferences/MyApp-nodejs`
+		- Windows: `%APPDATA%\MyApp-nodejs\Config` (for example, `C:\Users\USERNAME\AppData\Roaming\MyApp-nodejs\Config`)
+		- Linux: `~/.config/MyApp-nodejs` (or `$XDG_CONFIG_HOME/MyApp-nodejs`)
 		*/
 		readonly config: string;
 
 		/**
 		Directory for non-essential data files.
+
+		Example locations:
+
+		- macOS: `~/Library/Caches/MyApp-nodejs`
+		- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Cache` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Cache`)
+		- Linux: `~/.cache/MyApp-nodejs` (or `$XDG_CACHE_HOME/MyApp-nodejs`)
 		*/
 		readonly cache: string;
 
 		/**
 		Directory for log files.
+
+		Example locations:
+
+		- macOS: `~/Library/Logs/MyApp-nodejs`
+		- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Log` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Log`)
+		- Linux: `~/.local/state/MyApp-nodejs` (or `$XDG_STATE_HOME/MyApp-nodejs`)
 		*/
 		readonly log: string;
 
 		/**
 		Directory for temporary files.
+
+		Example locations (with the default `nodejs` [suffix](#suffix)):
+
+		- macOS: `/var/folders/jf/f2twvvvs5jl_m49tf034ffpw0000gn/T/MyApp-nodejs`
+		- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (for example, `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`)
+		- Linux: `/tmp/USERNAME/MyApp-nodejs`
 		*/
 		readonly temp: string;
 	}

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Directory for data files.
 Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `~/Library/Application Support/MyApp-nodejs`
-- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Data` (e.g., `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Data`)
+- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Data` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Data`)
 - Linux: `~/.local/share/MyApp-nodejs` (or `$XDG_DATA_HOME/MyApp-nodejs`)
 
 ### paths.config
@@ -69,7 +69,7 @@ Directory for config files.
 Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `~/Library/Preferences/MyApp-nodejs`
-- Windows: `%APPDATA%\MyApp-nodejs\Config` (e.g., `C:\Users\USERNAME\AppData\Roaming\MyApp-nodejs\Config`)
+- Windows: `%APPDATA%\MyApp-nodejs\Config` (for example, `C:\Users\USERNAME\AppData\Roaming\MyApp-nodejs\Config`)
 - Linux: `~/.config/MyApp-nodejs` (or `$XDG_CONFIG_HOME/MyApp-nodejs`)
 
 ### paths.cache
@@ -79,7 +79,7 @@ Directory for non-essential data files.
 Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `~/Library/Caches/MyApp-nodejs`
-- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Cache` (e.g., `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Cache`)
+- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Cache` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Cache`)
 - Linux: `~/.cache/MyApp-nodejs` (or `$XDG_CACHE_HOME/MyApp-nodejs`)
 
 ### paths.log
@@ -89,7 +89,7 @@ Directory for log files.
 Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `~/Library/Logs/MyApp-nodejs`
-- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Log` (e.g., `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Log`)
+- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Log` (for example, `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Log`)
 - Linux: `~/.local/state/MyApp-nodejs` (or `$XDG_STATE_HOME/MyApp-nodejs`)
 
 ### paths.temp
@@ -99,7 +99,7 @@ Directory for temporary files.
 Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `/var/folders/jf/f2twvvvs5jl_m49tf034ffpw0000gn/T/MyApp-nodejs`
-- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (e.g., `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`; )
+- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (for example, `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`; )
 - Linux: `/tmp/MyApp-nodejs`
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,12 @@ apps. Pass an empty string to disable it.
 
 Directory for data files.
 
+Example locations (with the default `nodejs` [suffix](#suffix)):
+
+- macOS: `~/Library/Application Support/MyApp-nodejs`
+- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Data` (e.g., `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Data`)
+- Linux: `~/.local/share/MyApp-nodejs` (or `$XDG_DATA_HOME/MyApp-nodejs`)
+
 ### paths.config
 
 Directory for config files.
@@ -70,14 +76,31 @@ Example locations (with the default `nodejs` [suffix](#suffix)):
 
 Directory for non-essential data files.
 
+Example locations (with the default `nodejs` [suffix](#suffix)):
+
+- macOS: `~/Library/Caches/MyApp-nodejs`
+- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Cache` (e.g., `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Cache`)
+- Linux: `~/.cache/MyApp-nodejs` (or `$XDG_CACHE_HOME/MyApp-nodejs`)
+
 ### paths.log
 
 Directory for log files.
+
+Example locations (with the default `nodejs` [suffix](#suffix)):
+
+- macOS: `~/Library/Logs/MyApp-nodejs`
+- Windows: `%LOCALAPPDATA%\MyApp-nodejs\Log` (e.g., `C:\Users\USERNAME\AppData\Local\MyApp-nodejs\Log`)
+- Linux: `~/.local/state/MyApp-nodejs` (or `$XDG_STATE_HOME/MyApp-nodejs`)
 
 ### paths.temp
 
 Directory for temporary files.
 
+Example locations (with the default `nodejs` [suffix](#suffix)):
+
+- macOS: `/var/folders/jf/f2twvvvs5jl_m49tf034ffpw0000gn/T/MyApp-nodejs`
+- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (e.g., `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`; )
+- Linux: `/tmp/MyApp-nodejs`
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Directory for temporary files.
 Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `/var/folders/jf/f2twvvvs5jl_m49tf034ffpw0000gn/T/MyApp-nodejs`
-- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (for example, `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`; )
+- Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (for example, `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`)
 - Linux: `/tmp/MyApp-nodejs`
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `/var/folders/jf/f2twvvvs5jl_m49tf034ffpw0000gn/T/MyApp-nodejs`
 - Windows: `%LOCALAPPDATA%\Temp\MyApp-nodejs` (for example, `C:\Users\USERNAME\AppData\Local\Temp\MyApp-nodejs`)
-- Linux: `/tmp/MyApp-nodejs`
+- Linux: `/tmp/USERNAME/MyApp-nodejs`
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Directory for config files.
 Example locations (with the default `nodejs` [suffix](#suffix)):
 
 - macOS: `~/Library/Preferences/MyApp-nodejs`
-- Windows: `%APPDATA%\MyApp-nodejs\Config`
+- Windows: `%APPDATA%\MyApp-nodejs\Config` (e.g., `C:\Users\USERNAME\AppData\Roaming\MyApp-nodejs\Config`)
 - Linux: `~/.config/MyApp-nodejs` (or `$XDG_CONFIG_HOME/MyApp-nodejs`)
 
 ### paths.cache

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,12 @@ Directory for data files.
 
 Directory for config files.
 
+Example locations (with the default `nodejs` [suffix](#suffix)):
+
+- macOS: `~/Library/Preferences/MyApp-nodejs`
+- Windows: `%APPDATA%\MyApp-nodejs\Config`
+- Linux: `~/.config/MyApp-nodejs` (or `$XDG_CONFIG_HOME/MyApp-nodejs`)
+
 ### paths.cache
 
 Directory for non-essential data files.


### PR DESCRIPTION
Resolves #15 

This PR adds examples of `paths` directories on macOS, Windows and Linux to `readme.md` ([rendered](https://github.com/sindresorhus/env-paths/blob/0b20ba6c908fa4e634142de89bfeda6510a947e8/readme.md#pathsdata)) and `index.d.ts`.